### PR TITLE
add the rank_binary image and the edit date to the floorplan

### DIFF
--- a/pyneato/account.py
+++ b/pyneato/account.py
@@ -174,6 +174,8 @@ class Account:
                 uuid = floorplan["floorplan_uuid"],
                 name = floorplan["name"],
                 rank_uuid = floorplan["rank_uuid"],
+                rank_binary = floorplan["processed_rank_binary"],
+                last_modified_at = floorplan["last_modified_at"],
             )
             self._floorplans.append(floorplan_object)
 

--- a/pyneato/floorplan.py
+++ b/pyneato/floorplan.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 
 from .session import Session
@@ -37,12 +38,31 @@ TRACK_SCHEMA = Schema(
 )
 
 class Floorplan:
-    def __init__(self, session: Session, uuid: str, name: str | None, rank_uuid: str):
+    def __init__(
+        self,
+        session: Session,
+        uuid: str,
+        name: str | None,
+        rank_uuid: str,
+        rank_binary: str,
+        last_modified_at: str,
+    ):
         self._session = session
         self.name = name
         self.uuid = uuid
         self.rank_uuid = rank_uuid
         self._tracks = set()
+        self.last_modified_at = last_modified_at
+        self._rank_binary = rank_binary
+
+    @property
+    def rank_image(self) -> str:
+        """
+        Get the binary image of the floorplan
+
+        :return: The image of the floorplan
+        """
+        return base64.b64decode(self._rank_binary)
 
     @property
     def tracks(self):


### PR DESCRIPTION
The new function returns the rank image in bytes. This allows a camera card to show the image. This is similar to what @stianaske did in [pybotvac](https://github.com/stianaske/pybotvac). A pull request for  home-assistant-myneato will follow, but it needs a new version for this repository. Can I update the version in setup.py here?